### PR TITLE
Add Scalingo Deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Deploy on Heroku:
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 Note: if you get a `$ROOT_URL, if specified, must be an URL.` error on deployment, double-check that you're providing the correct URL (typically `http://your-app-name-here.herokuapp.com`).
+
+Deploy on Scalingo:
+
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/TelescopeJS/sample-project/)

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,8 @@
+{
+  "name": "Telescope",
+  "description": "An open-source community app built with Meteor",
+  "repository": "https://github.com/TelescopeJS/sample-project/",
+  "logo": "http://www.telescopeapp.org/images/logo.png",
+  "website": "http://www.telescopeapp.org/",
+  "addons": ["scalingo-mongodb"]
+}


### PR DESCRIPTION
Scalingo is a PaaS that supports Meteor pretty well, we've done a lot of work to make things work out of the box. Oplog and horizontal scaling are available for further needs. Meteor is a really promising technology and we'd be glad helping this project to grow. So this PR is in the continuity of the heroku deploy button and works the same way to let users deploy their own version of 'Telescope' in an instant.

You can test the button (link to fork) here : https://github.com/Zyko0/sample-project/tree/one_click