### PR TITLE
Use NPM 3+ to ensure dependencies are installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "Nova",
   "version": "0.0.0",
+  "engines": {
+    "npm": "^3.0"
+  },
   "dependencies": {
     "bootstrap": "^4.0.0-alpha.2",
     "classnames": "^2.2.3",


### PR DESCRIPTION
NPM 2 results in an 'unmet peer dependency error' when trying to `npm install`, no problem with npm 3+